### PR TITLE
fix: Import Json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "screeps-room-planner-next",
+  "name": "screeps-room-planner",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "screeps-room-planner-next",
+      "name": "screeps-room-planner",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.4",

--- a/src/components/actions/ImportFromJson.tsx
+++ b/src/components/actions/ImportFromJson.tsx
@@ -60,7 +60,8 @@ export default function ImportJsonStructures() {
     resetStructurePositions();
 
     Object.entries(json.structures).forEach(([structure, positions]) => {
-      positions.forEach((shortPoint) => {
+      positions.forEach((point) => {
+        let shortPoint = point.x + '-' + point.y;
         const tile = getTileForShort(shortPoint);
         addTileStructure(tile, structure);
         addStructurePosition(structure, shortPoint);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export type Point = { x: number; y: number };
 
-export type RoomStructures = { [structure: string]: string[] };
+export type RoomStructures = { [structure: string]: Point[] };
 
 export type RoomStructuresJson = {
   rcl?: number;


### PR DESCRIPTION
Fixes bug with import json feature. It was parsing the old string position format (`x-y`) instead of objects (`{ x, y }`)

Closes #2